### PR TITLE
Encapsulate HTTP requests

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -1,9 +1,9 @@
-import axios, { AxiosBasicCredentials, AxiosInstance, AxiosProxyConfig, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosProxyConfig, AxiosRequestConfig } from 'axios';
 import { IProxyConfig } from '../model/ProxyConfig';
 
 export class HttpClient {
     private USER_AGENT_HEADER: string = 'User-Agent';
-    private _basicCredentials: AxiosBasicCredentials | undefined;
+    private _basicAuth: BasicAuth;
     private _axiosInstance: AxiosInstance;
 
     constructor(config: IHttpConfig) {
@@ -14,20 +14,20 @@ export class HttpClient {
             headers: config.headers,
             proxy: this.getAxiosProxyConfig(config.proxy)
         } as AxiosRequestConfig);
-        this._basicCredentials = {
+        this._basicAuth = {
             username: config.username,
             password: config.password
-        } as AxiosBasicCredentials;
+        } as BasicAuth;
     }
 
-    public async doRequest(httpOptions: AxiosRequestConfig): Promise<any> {
-        const { data } = await this._axiosInstance(httpOptions);
+    public async doRequest(requestParams: IRequestParams): Promise<any> {
+        const { data } = await this._axiosInstance(requestParams);
         return data;
     }
 
-    public async doAuthRequest(httpOptions: AxiosRequestConfig): Promise<any> {
-        httpOptions.auth = this._basicCredentials;
-        return this.doRequest(httpOptions);
+    public async doAuthRequest(requestParams: IRequestParams): Promise<any> {
+        requestParams.auth = this._basicAuth;
+        return this.doRequest(requestParams);
     }
 
     private addUserAgentHeader(headers: { [key: string]: string }) {
@@ -63,10 +63,25 @@ export class HttpClient {
     }
 }
 
+interface BasicAuth {
+    username: string;
+    password: string;
+}
+
 export interface IHttpConfig {
     serverUrl?: string;
     username?: string;
     password?: string;
     proxy?: IProxyConfig | false;
     headers?: { [key: string]: string };
+}
+
+export type method = 'GET' | 'POST';
+
+export interface IRequestParams {
+    url: string;
+    method: method;
+    data?: any;
+    auth?: BasicAuth;
+    timeout?: number;
 }

--- a/src/SummaryClient.ts
+++ b/src/SummaryClient.ts
@@ -1,7 +1,6 @@
-import { AxiosRequestConfig } from 'axios';
 import { ISummaryRequestModel } from '../model/Summary/SummaryRequestModel';
 import { ISummaryResponse } from '../model/Summary/SummaryResponse';
-import { HttpClient } from './HttpClient';
+import { HttpClient, IRequestParams } from './HttpClient';
 
 export class SummaryClient {
     private readonly summaryComponentsEndpoint = '/api/v1/summary/component';
@@ -9,11 +8,11 @@ export class SummaryClient {
     constructor(private readonly httpClient: HttpClient) {}
 
     public async component(model: ISummaryRequestModel): Promise<ISummaryResponse> {
-        const httpOptions: AxiosRequestConfig = {
+        const requestParams: IRequestParams = {
             url: this.summaryComponentsEndpoint,
-            method: 'post',
+            method: 'POST',
             data: model
         };
-        return await this.httpClient.doAuthRequest(httpOptions);
+        return await this.httpClient.doAuthRequest(requestParams);
     }
 }

--- a/src/SystemClient.ts
+++ b/src/SystemClient.ts
@@ -1,6 +1,5 @@
-import { AxiosRequestConfig } from 'axios';
 import { IVersion } from '../model/System/Version';
-import { HttpClient } from './HttpClient';
+import { HttpClient, IRequestParams } from './HttpClient';
 
 export class SystemClient {
     private readonly pingEndpoint = '/api/v1/system/ping';
@@ -9,23 +8,23 @@ export class SystemClient {
     constructor(private readonly httpClient: HttpClient) {}
 
     public async ping(): Promise<boolean> {
-        const httpOptions: AxiosRequestConfig = {
+        const requestParams: IRequestParams = {
             url: this.pingEndpoint,
-            method: 'get',
+            method: 'GET',
             timeout: 2000
         };
         try {
-            return await this.httpClient.doRequest(httpOptions);
+            return await this.httpClient.doRequest(requestParams);
         } catch (error) {
             return false;
         }
     }
 
     public async version(): Promise<IVersion> {
-        const httpOptions: AxiosRequestConfig = {
+        const requestParams: IRequestParams = {
             url: this.versionEndpoint,
-            method: 'get'
+            method: 'GET'
         };
-        return await this.httpClient.doAuthRequest(httpOptions);
+        return await this.httpClient.doAuthRequest(requestParams);
     }
 }


### PR DESCRIPTION
Make `doRequest` and `doAuthRequest` receive an internal `IRequestParams` interface instead of `AxiosRequestConfig`.

Related to: https://github.com/jfrog/jfrog-vscode-extension/pull/32