### PR TITLE
Add CVE to Issue and more tests

### DIFF
--- a/model/Summary/Cve.ts
+++ b/model/Summary/Cve.ts
@@ -1,0 +1,4 @@
+export interface ICve {
+    cve: string;
+    cvss_v2: string;
+}

--- a/model/Summary/Issue.ts
+++ b/model/Summary/Issue.ts
@@ -1,4 +1,5 @@
 import { Severity } from '../Severity';
+import { ICve } from './Cve';
 import { IVulnerableComponent } from './VulnerableComponent';
 
 export interface IIssue {
@@ -10,4 +11,5 @@ export interface IIssue {
     issue_type: string;
     impact_path: string;
     components: IVulnerableComponent[];
+    cves: ICve[];
 }

--- a/model/Summary/VulnerableComponent.ts
+++ b/model/Summary/VulnerableComponent.ts
@@ -1,3 +1,4 @@
 export interface IVulnerableComponent {
+    component_id: string;
     fixed_versions: string[];
 }

--- a/model/Summary/index.ts
+++ b/model/Summary/index.ts
@@ -1,5 +1,6 @@
 export { IArtifact } from './Artifact';
 export { ComponentDetails } from './ComponentDetails';
+export { ICve } from './Cve';
 export { IGeneral } from './General';
 export { IIssue } from './Issue';
 export { ILicense } from './License';

--- a/test/SummaryClient.spec.ts
+++ b/test/SummaryClient.spec.ts
@@ -94,10 +94,8 @@ describe('Xray summary tests', () => {
 
         const components: IVulnerableComponent[] | undefined = testIssue?.components;
         expect(components).toBeTruthy();
-        if (!components) {
-            return;
-        }
-        const expressComponent: IVulnerableComponent | undefined = components.find((component) => component.component_id === 'express');
+
+        const expressComponent: IVulnerableComponent | undefined = components?.find((component) => component.component_id === 'express');
         expect(expressComponent).toBeTruthy();
         const fixedVersions: string[] | undefined = expressComponent?.fixed_versions;
         expect(fixedVersions).toBeTruthy();


### PR DESCRIPTION
Related to: https://github.com/jfrog/jfrog-vscode-extension/pull/71.
Tests passed: https://github.com/yahavi/xray-client-js/actions/runs/261590122

Support CVE in summary/issue model as receives from Xray.
```json
"issue": {
    "cves": [
    {
        "cve": "cve-1",
        "cvss_v2": "cvss_v2-1"
    },
    {
        "cve": "cve-2",
        "cvss_v2": "cvss_v2-2"
    }]
}

```

Due to the similarity to the fixed-versions, I added also tests for fixed-versions.